### PR TITLE
Migrate to `ff 0.14`, `rand 0.9`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bumped MSRV to 1.63.0
+
 ### Added
 - `sinsemilla::CommitDomain::new_with_separate_domains`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
 dependencies = [
  "rand_core",
  "subtle",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
 dependencies = [
  "ff",
  "rand_core",
@@ -55,8 +55,7 @@ dependencies = [
 [[package]]
 name = "pasta_curves"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+source = "git+https://github.com/zcash/pasta_curves.git?rev=32152d552b1c39fb3ffab8f0d8646f946c4adecc#32152d552b1c39fb3ffab8f0d8646f946c4adecc"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -68,18 +67,18 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "sinsemilla"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Ying Tong Lai",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 description = "A collision-resistant circuit-efficient hash function"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/sinsemilla"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,12 @@ repository = "https://github.com/zcash/sinsemilla"
 categories = ["cryptography"]
 
 [dependencies]
-group = "0.13"
+group = "=0.14.0-pre.0"
 pasta_curves = { version = "0.5", default-features = false, features = ["alloc"] }
 subtle = { version = "2.3", default-features = false }
 
 [features]
 test-dependencies = []
+
+[patch.crates-io]
+pasta_curves = { git = "https://github.com/zcash/pasta_curves.git", rev = "32152d552b1c39fb3ffab8f0d8646f946c4adecc" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.63.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Blocked on:
- https://github.com/zkcrypto/ff/pull/130
- https://github.com/zkcrypto/group/pull/63
- https://github.com/zcash/pasta_curves/pull/86